### PR TITLE
bug: nginx /@vite/ 경로 웹소켓 프록시 설정

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,16 +33,18 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-
-     location /ws/ {
-       proxy_pass http://backend;                    # WebSocket 요청을 backend로 프록시
-       proxy_http_version 1.1;                      # WebSocket 연결에 필요한 HTTP 1.1 사용
-       proxy_set_header Upgrade $http_upgrade;      # WebSocket 프로토콜로 업그레이드
-       proxy_set_header Connection "upgrade";       # 업그레이드 연결 지정
-       proxy_set_header Host $host;                 # 클라이언트 요청의 Host 헤더 전달
-       proxy_set_header X-Real-IP $remote_addr;     # 클라이언트의 실제 IP 전달
-       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-     }
+    # Vite HMR WebSocket 프록시
+    location /@vite/ {
+      proxy_pass http://frontend;                # Vite 개발 서버
+      proxy_http_version 1.1;                    # WebSocket 연결을 위해 HTTP 1.1 사용
+      proxy_set_header Upgrade $http_upgrade;    # WebSocket 업그레이드 설정
+      proxy_set_header Connection "upgrade";     # 연결 업그레이드 설정
+      proxy_set_header Host $host;               # 클라이언트 요청의 Host 헤더 전달
+      proxy_set_header X-Real-IP $remote_addr;   # 클라이언트 실제 IP 전달
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_read_timeout 180s;                    # 읽기 타임아웃
+      proxy_send_timeout 180s;                    # 쓰기 타임아웃
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
nginx에서 /@vite/ 경로에 대해 웹소켓 프록시 하지 못하는 문제 해결

## Description
- /@vite/ 경로 추가, 기존 불필요한 백엔드 웹소켓 /ws/경로 삭제

## Test Checklist
- [ ] 리액트 url 요청하였을 때 개발자 모드에서 웹소켓 오류가 발생하는지 체크
