### PR TITLE
setting: prometheus 통신을 위한 nginx-exporter 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,18 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:0.10.0
+    container_name: nginx_prometheus_exporter
+    ports:
+      - "9113:9113" # Prometheus가 메트릭을 수집할 포트
+    command:
+      - -nginx.scrape-uri=http://ppurisam_nginx/metrics
+    depends_on:
+      - nginx
+    networks:
+      - ppurisam_network
+
   grafana:
     image: grafana/grafana:latest
     container_name: ppurisam_grafana

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -77,15 +77,21 @@ http {
 
         # Vite HMR WebSocket 프록시
         location /@vite/ {
-        proxy_pass http://frontend;                # Vite 개발 서버
-        proxy_http_version 1.1;                    # WebSocket 연결을 위해 HTTP 1.1 사용
-        proxy_set_header Upgrade $http_upgrade;    # WebSocket 업그레이드 설정
-        proxy_set_header Connection "upgrade";     # 연결 업그레이드 설정
-        proxy_set_header Host $host;               # 클라이언트 요청의 Host 헤더 전달
-        proxy_set_header X-Real-IP $remote_addr;   # 클라이언트 실제 IP 전달
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_read_timeout 180s;                    # 읽기 타임아웃
-        proxy_send_timeout 180s;                    # 쓰기 타임아웃
+            proxy_pass http://frontend;                # Vite 개발 서버
+            proxy_http_version 1.1;                    # WebSocket 연결을 위해 HTTP 1.1 사용
+            proxy_set_header Upgrade $http_upgrade;    # WebSocket 업그레이드 설정
+            proxy_set_header Connection "upgrade";     # 연결 업그레이드 설정
+            proxy_set_header Host $host;               # 클라이언트 요청의 Host 헤더 전달
+            proxy_set_header X-Real-IP $remote_addr;   # 클라이언트 실제 IP 전달
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_read_timeout 180s;                    # 읽기 타임아웃
+            proxy_send_timeout 180s;                    # 쓰기 타임아웃
         }
+
+         # Prometheus 메트릭 엔드포인트 설정
+         location /metrics {
+             stub_status;      # Nginx 상태 정보를 노출
+             allow all;        # 추후 배포할 때 수정 필요
+         }
    }
 }


### PR DESCRIPTION
## Summary
prometheus와 통신하기 위해서 nginx-prometheus-exporter 설정

## Description
- exporter 이미지 파일 추가 
- nginx metrics 엔드포인트 추가

## Test Checklist
- [ ] 도커 파일 잘 올라가는지 확인
